### PR TITLE
upgpkg: gnome-shell-extension-workspace-matrix 6.0-1

### DIFF
--- a/gnome-shell-extension-workspace-matrix/.SRCINFO
+++ b/gnome-shell-extension-workspace-matrix/.SRCINFO
@@ -1,12 +1,12 @@
 pkgbase = gnome-shell-extension-workspace-matrix
 	pkgdesc = Arrange workspaces in a two dimensional grid with workspace thumbnails
-	pkgver = 6.0.0_beta
+	pkgver = 6.0
 	pkgrel = 1
 	url = https://github.com/mzur/gnome-shell-wsmatrix
 	arch = x86_64
 	license = GPL3
 	depends = gnome-shell
-	source = gnome-shell-extension-workspace-matrix-6.0.0_beta-1.tar.gz::https://github.com/mzur/gnome-shell-wsmatrix/archive/v6.0.0-beta.tar.gz
-	sha256sums = d2c4048e9a265657c061899ace821309e6c2639912532500317cd4b020338a98
+	source = gnome-shell-extension-workspace-matrix-6.0-1.tar.gz::https://github.com/mzur/gnome-shell-wsmatrix/archive/v6.0.tar.gz
+	sha256sums = 907c8fed613c70446cd6b68a983ebebe9517e6e5369b3a7a502b98b379e84bac
 
 pkgname = gnome-shell-extension-workspace-matrix

--- a/gnome-shell-extension-workspace-matrix/PKGBUILD
+++ b/gnome-shell-extension-workspace-matrix/PKGBUILD
@@ -3,21 +3,20 @@
 
 pkgname=gnome-shell-extension-workspace-matrix
 _repo=gnome-shell-wsmatrix
-_pkgver=6.0.0-beta
-pkgver=${_pkgver/-/_}
+pkgver=6.0
 pkgrel=1
 pkgdesc='Arrange workspaces in a two dimensional grid with workspace thumbnails'
 arch=(x86_64)
 url=https://github.com/mzur/gnome-shell-wsmatrix
 license=(GPL3)
 depends=(gnome-shell)
-source=(${pkgname}-${pkgver}-${pkgrel}.tar.gz::https://github.com/mzur/${_repo}/archive/v${_pkgver}.tar.gz)
-sha256sums=('d2c4048e9a265657c061899ace821309e6c2639912532500317cd4b020338a98')
+source=(${pkgname}-${pkgver}-${pkgrel}.tar.gz::https://github.com/mzur/${_repo}/archive/v${pkgver}.tar.gz)
+sha256sums=('907c8fed613c70446cd6b68a983ebebe9517e6e5369b3a7a502b98b379e84bac')
 
 _uuid=wsmatrix@martin.zurowietz.de
 
 package() {
-  cd ${_repo}-${_pkgver}/${_uuid}
+  cd ${_repo}-${pkgver}/${_uuid}
   install -Dm644 metadata.json settings.ui *.js -t "${pkgdir}/usr/share/gnome-shell/extensions/${_uuid}/"
   install -Dm644 "schemas/org.gnome.shell.extensions.wsmatrix.gschema.xml" -t "${pkgdir}/usr/share/glib-2.0/schemas/"
 }


### PR DESCRIPTION
upstream release