### PR TITLE
mkdir -p build instead of mkdir build

### DIFF
--- a/thelounge-beta/PKGBUILD
+++ b/thelounge-beta/PKGBUILD
@@ -39,7 +39,7 @@ prepare() {
 }
 
 build() {
-    mkdir _build
+    mkdir -p _build
     cp package.json yarn.lock _build
     cd _build
 


### PR DESCRIPTION
Prevent failure on consecutive makepkgs