### PR TITLE
spotdl rapidfuzz

### DIFF
--- a/ci/python-spotdl/before_makepkg.sh
+++ b/ci/python-spotdl/before_makepkg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 pacman -Syu git --noconfirm
-for i in {python-rapidfuzz-capi,python-jarowinkler,python-spotipy,python-pytube,python-rapidfuzz,python-ytmusicapi}; do
+for i in {python-rapidfuzz-capi,python-jarowinkler,python-spotipy,python-pytube,rapidfuzz-cpp,jarowinkler-cpp,python-rapidfuzz,python-ytmusicapi}; do
         git clone "https://aur.archlinux.org/$i.git"
         chown -R devel: "$i"
         su devel sh -c "cd $i && makepkg -sri --noconfirm"


### PR DESCRIPTION
- Install rapidfuzz-cpp,jarowinkler-cpp before python-spotdl makepkg
- upgpkg: python-spotdl 3.9.5-2
