### PR TITLE
makepkg cpp-taskflow before python-rapidfuzz

### DIFF
--- a/ci/python-spotdl/before_makepkg.sh
+++ b/ci/python-spotdl/before_makepkg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 pacman -Syu git --noconfirm
-for i in {python-rapidfuzz-capi,python-jarowinkler,python-spotipy,python-pytube,rapidfuzz-cpp,jarowinkler-cpp,python-rapidfuzz,python-ytmusicapi}; do
+for i in {cpp-taskflow,python-rapidfuzz-capi,python-jarowinkler,python-spotipy,python-pytube,rapidfuzz-cpp,jarowinkler-cpp,python-rapidfuzz,python-ytmusicapi}; do
         git clone "https://aur.archlinux.org/$i.git"
         chown -R devel: "$i"
         su devel sh -c "cd $i && makepkg -sri --noconfirm"


### PR DESCRIPTION
Needed for python-spotdl before_makepkg
