### PR TITLE
spotdl fix

### DIFF
--- a/ci/python-spotdl/before_makepkg.sh
+++ b/ci/python-spotdl/before_makepkg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 pacman -Syu git --noconfirm
-for i in {cpp-taskflow,python-rapidfuzz-capi,python-jarowinkler,python-spotipy,python-pytube,rapidfuzz-cpp,jarowinkler-cpp,python-rapidfuzz,python-ytmusicapi}; do
+for i in {cpp-taskflow,jarowinkler-cpp,python-rapidfuzz-capi,python-jarowinkler,python-spotipy,python-pytube,rapidfuzz-cpp,python-rapidfuzz,python-ytmusicapi}; do
         git clone "https://aur.archlinux.org/$i.git"
         chown -R devel: "$i"
         su devel sh -c "cd $i && makepkg -sri --noconfirm"

--- a/python-spotdl/PKGBUILD
+++ b/python-spotdl/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: zoorat <zoorat [at] protonmail [dot] com>
+# Maintainer: Amin Vakil <info AT aminvakil DOT com>
 # Contributor: Tim Schumacher <timschumi@gmx.de>
 # Contributor: Felix Yan <felixonmars@archlinux.org>
 # Contributor: Gordian Edenhofer <gordian.edenhofer[at]yahoo[dot]de>


### PR DESCRIPTION
- Install jarowinkler-cpp before python-jarowinkler
- upgpkg: python-spotdl 3.9.6-2
