### PR TITLE
wkhtmltopdf aur

### DIFF
--- a/ci/ravro_dcrpt-git/before_makepkg.sh
+++ b/ci/ravro_dcrpt-git/before_makepkg.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -eux
 pacman -Syu git --noconfirm
-for i in {wkhtmltopdf-static}; do
-        git clone "https://aur.archlinux.org/$i.git"
-        chown -R devel: "$i"
-        su devel sh -c "cd $i && makepkg -sri --noconfirm"
-done;
+git clone "https://aur.archlinux.org/wkhtmltopdf-static.git"
+chown -R devel: "wkhtmltopdf-static"
+su devel sh -c "cd wkhtmltopdf-static && makepkg -sri --noconfirm"

--- a/ci/ravro_dcrpt-git/before_makepkg.sh
+++ b/ci/ravro_dcrpt-git/before_makepkg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eux
 pacman -Syu git --noconfirm
-for i in {qt5-webkit,wkhtmltopdf}; do
+for i in {wkhtmltopdf-static}; do
         git clone "https://aur.archlinux.org/$i.git"
         chown -R devel: "$i"
         su devel sh -c "cd $i && makepkg -sri --noconfirm"

--- a/ci/ravro_dcrpt-git/before_makepkg.sh
+++ b/ci/ravro_dcrpt-git/before_makepkg.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eux
+pacman -Syu git --noconfirm
+for i in {qt5-webkit,wkhtmltopdf}; do
+        git clone "https://aur.archlinux.org/$i.git"
+        chown -R devel: "$i"
+        su devel sh -c "cd $i && makepkg -sri --noconfirm"
+done;

--- a/ci/ravro_dcrpt-git/before_makepkg.sh
+++ b/ci/ravro_dcrpt-git/before_makepkg.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
 pacman -Syu git --noconfirm
 for i in {qt5-webkit,wkhtmltopdf}; do

--- a/ravro_dcrpt-git/.SRCINFO
+++ b/ravro_dcrpt-git/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ravro_dcrpt-git
 	pkgdesc = Decrypt secret report files ravro
-	pkgver = r78.c7fb7fc
-	pkgrel = 2
+	pkgver = r101.7a20746
+	pkgrel = 1
 	url = https://github.com/ravro-ir/ravro_dcrpt
 	arch = any
 	license = unknown

--- a/ravro_dcrpt-git/PKGBUILD
+++ b/ravro_dcrpt-git/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Amin Vakil <info AT aminvakil DOT com>
 
 pkgname=ravro_dcrpt-git
-pkgver=r78.c7fb7fc
-pkgrel=2
+pkgver=r101.7a20746
+pkgrel=1
 pkgdesc="Decrypt secret report files ravro"
 arch=('any')
 url="https://github.com/ravro-ir/ravro_dcrpt"


### PR DESCRIPTION
- upgpkg: ravro_dcrpt-git r78.c7fb7fc-1
- qt5-webkit has been dropped from official repos
