### PR TITLE
butane bin gpg

### DIFF
--- a/butane-bin/PKGBUILD
+++ b/butane-bin/PKGBUILD
@@ -28,4 +28,3 @@ package() {
     mkdir -p ${pkgdir}/usr/bin
     install ${srcdir}/${_pkgname}-${CARCH}-unknown-linux-gnu ${pkgdir}/usr/bin/${_pkgname}
 }
-

--- a/butane-bin/PKGBUILD
+++ b/butane-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Amin Vakil <info AT aminvakil DOT com>
 
 # Before running makepkg, you must do this (as normal user):
-# curl https://getfedora.org/static/fedora.gpg | gpg --import
+# curl https://fedoraproject.org/fedora.gpg | gpg --import
 
 _pkgname=butane
 pkgname=butane-bin

--- a/ci/butane-bin/before_makepkg.sh
+++ b/ci/butane-bin/before_makepkg.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -eux
 pacman -Suy gnupg curl --noconfirm
-su devel sh -c "curl https://getfedora.org/static/fedora.gpg | gpg --import"
+su devel sh -c "curl https://fedoraproject.org/fedora.gpg | gpg --import"


### PR DESCRIPTION
- Change Fedora gpg key url
- upgpkg: butane-bin 0.18.0-1
