### PR TITLE
Fix running actionlint unit tests

### DIFF
--- a/actionlint/PKGBUILD
+++ b/actionlint/PKGBUILD
@@ -29,6 +29,9 @@ build() {
 
 check() {
   cd "$pkgname-$pkgver"
+  # To run tests for actionlint, `.git` directory is needed.
+  # actionlint finds a root of repository by checking the directory.
+  mkdir -p .git
   go test -v ./ ./scripts/...
 }
 


### PR DESCRIPTION
Related: https://github.com/rhysd/actionlint/issues/307.

actionlint's unit tests assume `.git` directory at root of repository. However, `.git` directory is not included in source tarballs provided by GitHub. This PR fixes the issue by making a fake `.git` directory.

After merging this branch, #274 should pass CI.