### PR TITLE
Set actionlint version with ldflags

### DIFF
--- a/actionlint/PKGBUILD
+++ b/actionlint/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=actionlint
 pkgver=1.6.25
-pkgrel=1
+pkgrel=2
 pkgdesc="Static checker for GitHub Actions workflow files"
 arch=('any')
 url="https://github.com/rhysd/actionlint"
@@ -24,7 +24,7 @@ build() {
   export CGO_CXXFLAGS="${CXXFLAGS}"
   export CGO_LDFLAGS="${LDFLAGS}"
   export GOFLAGS="-buildmode=pie -trimpath -ldflags=-linkmode=external -mod=readonly -modcacherw"
-  go build -o build ./cmd/${pkgname}
+  go build -ldflags "-X github.com/rhysd/actionlint.version=$pkgver" -o build ./cmd/${pkgname}
 }
 
 check() {


### PR DESCRIPTION
`actionlint -version` doesn't work when you neither set it with ldflags nor install `actionlint` with `go install`. Now it outputs `(devel)` as version.

```console
$ actionlint -version
(devel)
installed by building from source
built with go1.20.5 compiler for linux/amd64
```

When I release new version of actionlint, [CI adds the version information with ldflags](https://github.com/rhysd/actionlint/blob/8cfb90b5bdbdb51d5f7749f60922d28bfad59fcc/.goreleaser.yaml#L12). However this AUR package builds actionlint by itself so the version is not set.

This PR adds the missing version information by specifying ldflags. After this patch, `actionlint -version` should work as follows:

```console
$ actionlint -version
1.6.25
installed by building from source
built with go1.20.5 compiler for linux/amd64
```