### PR TITLE
fix(ansible-cmdb): add missing python-jsonxs dependency

### DIFF
--- a/ansible-cmdb/.SRCINFO
+++ b/ansible-cmdb/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ansible-cmdb
 	pkgdesc = Generate host overview from ansible fact gathering output.
 	pkgver = 1.31
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/fboender/ansible-cmdb
 	arch = any
 	license = GPL3
@@ -13,6 +13,7 @@ pkgbase = ansible-cmdb
 	depends = python
 	depends = python-mako
 	depends = python-pyyaml
+	depends = python-jsonxs
 	source = git+https://github.com/gardar/ansible-cmdb.git#branch=fix-build
 	sha256sums = SKIP
 

--- a/ansible-cmdb/PKGBUILD
+++ b/ansible-cmdb/PKGBUILD
@@ -3,12 +3,12 @@
 
 pkgname=ansible-cmdb
 pkgver=1.31
-pkgrel=2
+pkgrel=3
 pkgdesc="Generate host overview from ansible fact gathering output."
 arch=('any')
 url="https://github.com/fboender/ansible-cmdb"
 license=('GPL3')
-depends=('python' 'python-mako' 'python-pyyaml')
+depends=('python' 'python-mako' 'python-pyyaml' 'python-jsonxs')
 makedepends=('python-setuptools' 'git' 'python-build' 'python-installer' 'python-wheel')
 # source=("${pkgname}-${pkgver}-${pkgrel}.tar.gz::${url}/archive/${pkgver}.tar.gz")
 source=("git+https://github.com/gardar/ansible-cmdb.git#branch=fix-build")

--- a/ci/ansible-cmdb/before_makepkg.sh
+++ b/ci/ansible-cmdb/before_makepkg.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eux
+pacman -Suy git --noconfirm
+git clone https://aur.archlinux.org/python-jsonxs.git
+chown -R devel: python-jsonxs
+su devel sh -c "cd python-jsonxs && makepkg -sri --noconfirm"


### PR DESCRIPTION
Apparently there is a hard requirement for jsonxs to be able to generate anything with ansible-cmdb