### PR TITLE
Update @actions/checkout to v4 to have them run on node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix: ${{ steps.changed-pkgs.outputs.matrix }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: retrieve changed pkgs
@@ -31,7 +31,7 @@ jobs:
       matrix: ${{fromJson(needs.changed_pkgs.outputs.matrix)}}
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Exit if pkg doesn't exist.
         run: if [ ! -d "${{ matrix.pkg }}" ]; then exit 1; fi
@@ -86,7 +86,7 @@ jobs:
       matrix: ${{fromJson(needs.changed_pkgs.outputs.matrix)}}
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Pull base image.
         run: docker pull quay.io/aminvakil/archlinux:latest

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -49,7 +49,7 @@ jobs:
           - pkg: zoiper-bin
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Exit if pkg doesn't exist.
         run: if [ ! -d "${{ matrix.pkg }}" ]; then exit 1; fi


### PR DESCRIPTION
This just updates the workflow to use Node 20 (instead of Node 16). The error that occurs is the same we had when I updated the set-output stuff because I didn't update any pkg.