### PR TITLE
Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This enables Dependabot for GitHub Actions to get PRs from Dependabot when there are new versions of GitHub Actions inside of your workflows. I thought this to be helpful, so I made a PR. Can close, if you don't want to have that.