### PR TITLE
spotdl python 3.12

### DIFF
--- a/spotdl/.SRCINFO
+++ b/spotdl/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = spotdl
 	pkgdesc = Download your Spotify playlists and songs along with album art and metadata (from YouTube if a match is found).
 	pkgver = 4.2.5
-	pkgrel = 4
+	pkgrel = 5
 	url = https://github.com/spotDL/spotify-downloader
 	arch = any
 	license = MIT
@@ -30,7 +30,7 @@ pkgbase = spotdl
 	depends = python-slugify
 	depends = python-spotipy
 	depends = python-syncedlyrics
-	depends = python-typing-extensions
+	depends = python-typing_extensions
 	depends = python-ytmusicapi
 	depends = uvicorn
 	depends = yt-dlp
@@ -38,6 +38,6 @@ pkgbase = spotdl
 	conflicts = python-spotdl
 	replaces = python-spotdl
 	source = spotdl-4.2.5.tar.gz::https://github.com/spotDL/spotify-downloader/archive/v4.2.5.tar.gz
-	b2sums = e7b1ba0c7bebceb0d78ea0b4974b7a2a46612f03a3b3e457f8f996d68b9b23df0c199448956ad5f4398effbe5d59d51c43c310f998a8d4798d07bb89f6c51a5d
+	b2sums = cb45720745936cb4e14fb121e34871614e5be4bdc10f0c23058f979dfd788dd7da06ceb3cc633c93fb7bf799080256f718e29f8ff30fba275be9c6c3f9eae2ca
 
 pkgname = spotdl

--- a/spotdl/PKGBUILD
+++ b/spotdl/PKGBUILD
@@ -7,7 +7,7 @@
 
 pkgname=spotdl
 pkgver=4.2.5
-pkgrel=4
+pkgrel=5
 
 pkgdesc='Download your Spotify playlists and songs along with album art and metadata (from YouTube if a match is found).'
 arch=('any')
@@ -36,7 +36,7 @@ depends=(
 	'python-slugify'
 	'python-spotipy'
 	'python-syncedlyrics'
-	'python-typing-extensions'
+	'python-typing_extensions'
 	'python-ytmusicapi'
 	'uvicorn'
 	'yt-dlp'


### PR DESCRIPTION
- **regenerate .SRCINFO**
- **fix `python-typing_extensions` dependency name**
