### PR TITLE
Disable google-tsunami-security-scanner-git build

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -34,7 +34,7 @@ jobs:
           - pkg: gnome-shell-extension-public-ip-git
           - pkg: gnome-shell-extension-workspace-matrix
           - pkg: google-tsunami-security-scanner
-          - pkg: google-tsunami-security-scanner-git
+          # - pkg: google-tsunami-security-scanner-git
           # - pkg: google-tsunami-security-scanner-plugins-git
           # - pkg: jmeter-plugins-manager
           - pkg: multi-git-status


### PR DESCRIPTION
Build fails in gradle 9.0.0
https://github.com/google/tsunami-security-scanner/issues/144
