### PR TITLE
Bump jmeter-plugins-manager version to 1.11

### DIFF
--- a/jmeter-plugins-manager/.SRCINFO
+++ b/jmeter-plugins-manager/.SRCINFO
@@ -1,13 +1,13 @@
 pkgbase = jmeter-plugins-manager
 	pkgdesc = Custom Plugins for Apache JMeter™
-	pkgver = 1.10
+	pkgver = 1.11
 	pkgrel = 1
 	url = http://jmeter-plugins.org/
 	arch = any
 	license = Apache
 	depends = jmeter>=3.0
 	options = !strip
-	source = jmeter-plugins-manager-1.10.jar::https://jmeter-plugins.org/get/
-	md5sums = a161fe2e5e6c0cad9f6f0f53135879f2
+	source = jmeter-plugins-manager-1.11.jar::https://jmeter-plugins.org/get/
+	md5sums = 6b9aa7744c17d1e35e87aaeb3d73821e
 
 pkgname = jmeter-plugins-manager

--- a/jmeter-plugins-manager/PKGBUILD
+++ b/jmeter-plugins-manager/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: Nicolas Quiénot <niQo @ aur>
 
 pkgname=jmeter-plugins-manager
-pkgver=1.10
+pkgver=1.11
 pkgrel=1
 pkgdesc="Custom Plugins for Apache JMeter™"
 arch=(any)
@@ -11,7 +11,7 @@ license=('Apache')
 depends=('jmeter>=3.0')
 options=(!strip)
 source=(${pkgname}-${pkgver}.jar::https://jmeter-plugins.org/get/)
-md5sums=('a161fe2e5e6c0cad9f6f0f53135879f2')
+md5sums=('6b9aa7744c17d1e35e87aaeb3d73821e')
 
 package() {
   install -Dm644 "${pkgname}-${pkgver}.jar" "${pkgdir}/opt/jmeter/lib/ext/${pkgname}-${pkgver}.jar"


### PR DESCRIPTION
The source URL (https://jmeter-plugins.org/get/) downloads the latest version 1.11, which caused the checksum validation to fail.