### PR TITLE
Rebuild with go 1.26.3

### DIFF
--- a/paqet/.SRCINFO
+++ b/paqet/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = paqet
 	pkgdesc = Ferries Packets Across Forbidden Boundaries
 	pkgver = 1.0.0_alpha.19
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/hanselime/paqet
 	arch = any
 	license = MIT

--- a/paqet/PKGBUILD
+++ b/paqet/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=paqet
 pkgver=1.0.0_alpha.19
-pkgrel=1
+pkgrel=2
 pkgdesc="Ferries Packets Across Forbidden Boundaries"
 arch=("any")
 url="https://github.com/hanselime/paqet"


### PR DESCRIPTION
This is not necessary for aur packages
